### PR TITLE
Apply newer entity syntax 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|8.*"
+        "php": "8.*"
     },
     "require-dev": {
         "symfony/maker-bundle": "^1.36"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e3a3d842e27be22a6f4be0fdc0a25a9",
+    "content-hash": "6ea5cf94257fc6ac700afa0f7535db12",
     "packages": [],
     "packages-dev": [
         {
@@ -2647,8 +2647,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4|8.*"
+        "php": "8.*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Maker/Entity/EntityTypes.php
+++ b/src/Maker/Entity/EntityTypes.php
@@ -66,7 +66,7 @@ class EntityTypes
             return 'integer';
         }
 
-        if (0 === strpos($snakeCasedField, 'is_') || 0 === strpos($snakeCasedField, 'has_')) {
+        if (str_starts_with($snakeCasedField, 'is_') || str_starts_with($snakeCasedField, 'has_')) {
             return 'boolean';
         }
 
@@ -108,6 +108,9 @@ class EntityTypes
                 '255',
                 [Validator::class, 'validateLength']
             );
+            if (255 === $data['length']) {
+                unset($data['length']);
+            }
         } elseif ('decimal' === $type || 'ap_decimal' === $type) {
             // 10 is the default value given in \Doctrine\DBAL\Schema\Column::$_precision
             $data['precision'] = (int) $io->ask(

--- a/src/Maker/Entity/Questionnaire.php
+++ b/src/Maker/Entity/Questionnaire.php
@@ -38,10 +38,7 @@ class Questionnaire
         return $question;
     }
 
-    /**
-     * @return string[]|EntityRelation|null
-     */
-    public function getNextField(ConsoleStyle $io, array $existingFields, string $entity)
+    public function getNextField(ConsoleStyle $io, array $existingFields, string $entity): array|EntityRelation|null
     {
         $fieldName = $this->getFieldName($io, $existingFields, $entity);
 

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -29,30 +29,16 @@ class MakeEntity extends PlainMaker implements InputAwareMakerInterface
 {
     use ClassProperties;
 
-    private Questionnaire $questionnaire;
-    private DoctrineHelper $doctrineHelper;
-    private EntityClassGenerator $entityClassGenerator;
-    private NamespaceService $namespaceService;
-    private ClassManipulatorManager $manipulatorManager;
-    private EntityTypes $entityTypes;
-
     public function __construct(
         Interactor $interactor,
-        Questionnaire $questionnaire,
-        DoctrineHelper $doctrineHelper,
-        EntityClassGenerator $entityClassGenerator,
-        NamespaceService $namespaceService,
-        ClassManipulatorManager $manipulatorManager,
-        EntityTypes $entityTypes
+        private Questionnaire $questionnaire,
+        private DoctrineHelper $doctrineHelper,
+        private EntityClassGenerator $entityClassGenerator,
+        private NamespaceService $namespaceService,
+        private ClassManipulatorManager $manipulatorManager,
+        private EntityTypes $entityTypes
     ) {
         parent::__construct($interactor);
-
-        $this->questionnaire = $questionnaire;
-        $this->doctrineHelper = $doctrineHelper;
-        $this->entityClassGenerator = $entityClassGenerator;
-        $this->namespaceService = $namespaceService;
-        $this->manipulatorManager = $manipulatorManager;
-        $this->entityTypes = $entityTypes;
     }
 
     public static function getCommandName(): string

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -6,27 +6,16 @@ namespace <?= $namespace ?>;
 
 use Doctrine\ORM\Mapping as ORM;
 
-<?php if (!$use_attributes || !$doctrine_use_attributes): ?>
-/**
- * @ORM\Entity()
-<?php if ($should_escape_table_name): ?> * @ORM\Table(name="`<?= $table_name ?>`")
-<?php endif ?>
- */
-<?php endif ?>
 <?php if ($doctrine_use_attributes): ?>
-#[ORM\Entity()]
+#[ORM\Entity]
 <?php if ($should_escape_table_name): ?>#[ORM\Table(name: '`<?= $table_name ?>`')]
 <?php endif ?>
 <?php endif?>
 class <?= $class_name."\n" ?>
 {
     public function __construct(
-        <?php if (!$doctrine_use_attributes): ?>/**
-        * @ORM\Id()
-        * @ORM\Column(type="string", length=255)
-        */
-        <?php else: ?>#[ORM\Id]
-        #[ORM\Column(type: 'string', length: 255)]
+        <?php if ($doctrine_use_attributes): ?>#[ORM\Id]
+        #[ORM\Column]
         <?php endif ?>private string $id,
     ) {
     }

--- a/src/Services/ClassGenerator/Doctrine/EntityClassGenerator.php
+++ b/src/Services/ClassGenerator/Doctrine/EntityClassGenerator.php
@@ -10,13 +10,10 @@ use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 
 class EntityClassGenerator
 {
-    private Generator $generator;
-    private DoctrineHelper $doctrineHelper;
-
-    public function __construct(Generator $generator, DoctrineHelper $doctrineHelper)
-    {
-        $this->generator = $generator;
-        $this->doctrineHelper = $doctrineHelper;
+    public function __construct(
+        private Generator $generator,
+        private DoctrineHelper $doctrineHelper,
+    ) {
     }
 
     public function generateEntityClass(

--- a/src/Services/ClassManipulator/ClassSourceManipulator.php
+++ b/src/Services/ClassManipulator/ClassSourceManipulator.php
@@ -41,9 +41,7 @@ class ClassSourceManipulator
     private const CONTEXT_CLASS_METHOD = 'class_method';
 
     private $overwrite;
-    protected bool $useAnnotations;
     private $fluentMutators;
-    protected bool $useAttributesForDoctrineMapping;
     private $parser;
     private $lexer;
     private PrettyPrinter $printer;
@@ -55,12 +53,10 @@ class ClassSourceManipulator
 
     private $pendingComments = [];
 
-    public function __construct(string $sourceCode, bool $overwrite = false, bool $useAnnotations = true, bool $fluentMutators = true, bool $useAttributesForDoctrineMapping = false)
+    public function __construct(string $sourceCode, bool $overwrite = false, protected bool $useAnnotations = true, bool $fluentMutators = true, protected bool $useAttributesForDoctrineMapping = false)
     {
         $this->overwrite = $overwrite;
-        $this->useAnnotations = $useAnnotations;
         $this->fluentMutators = $fluentMutators;
-        $this->useAttributesForDoctrineMapping = $useAttributesForDoctrineMapping;
         $this->lexer = new Lexer\Emulative([
             'usedAttributes' => [
                 'comments',
@@ -210,7 +206,13 @@ class ClassSourceManipulator
 
     public function addGetter(string $propertyName, $returnType, bool $isReturnTypeNullable, array $commentLines = []): void
     {
-        $methodName = 'get' . Str::asCamelCase($propertyName);
+        $methodName = Str::asCamelCase($propertyName);
+        if (!(
+            str_starts_with(Str::asSnakeCase($propertyName), 'is_')
+            || str_starts_with(Str::asSnakeCase($propertyName), 'has_')
+        )) {
+            $methodName = 'get' . Str::asCamelCase($propertyName);
+        }
 
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
@@ -992,7 +994,11 @@ class ClassSourceManipulator
     public function buildAttributeNode(string $attributeClass, array $options, ?string $attributePrefix = null): Node\Attribute
     {
         $options = $this->sortOptionsByClassConstructorParameters($options, $attributeClass);
-
+        if (true === isset($options['type'])) {
+            if (true === in_array($options['type'], ['string', 'bool', 'int', 'boolean', 'integer'])) {
+                unset($options['type']);
+            }
+        }
         $context = $this;
         $nodeArguments = array_map(static function ($option, $value) use ($context) {
             return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));

--- a/src/Services/ClassManipulator/ClassSourceManipulator.php
+++ b/src/Services/ClassManipulator/ClassSourceManipulator.php
@@ -226,21 +226,13 @@ class ClassSourceManipulator
                 new Node\Expr\Variable($propertyName)
             ))
         );
-        $this->makeMethodFluent($builder);
+        $builder->setReturnType('void');
         $this->addMethod($builder->getNode());
     }
 
     public function addEntitySetter(string $propertyName, $type, bool $isNullable, array $commentLines = []): void
     {
-        $builder = $this->createSetterNodeBuilder($propertyName, $type, $isNullable, $commentLines);
-        $builder->addStmt(
-            new Node\Stmt\Expression(new Node\Expr\Assign(
-                new Node\Expr\PropertyFetch(new Node\Expr\Variable('this'), $propertyName),
-                new Node\Expr\Variable($propertyName)
-            ))
-        );
-        $builder->setReturnType('void');
-        $this->addMethod($builder->getNode());
+        $this->addSetter($propertyName, $type, $isNullable, $commentLines);
     }
 
     /**

--- a/src/Services/ClassManipulator/EntityManipulator.php
+++ b/src/Services/ClassManipulator/EntityManipulator.php
@@ -7,6 +7,7 @@ namespace Bornfight\MabooMakerBundle\Services\ClassManipulator;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\Column;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -25,12 +26,16 @@ class EntityManipulator extends ClassManipulator
     public function addField(string $propertyName, array $columnOptions, array $comments = []): void
     {
         $typeHint = $this->getTypeHint($columnOptions['type']);
+        $columnType = $this->getColumnType($columnOptions['type']);
         $typeHintShortName = Str::getShortClassName($typeHint);
         $nullable = $columnOptions['nullable'] ?? false;
         $isId = (bool) ($columnOptions['id'] ?? false);
         $attributes = [];
 
         if (true === $this->useAttributesForDoctrineMapping) {
+            if (null !== $columnType) {
+                $columnOptions['type'] = $columnType;
+            }
             $attributes[] = $this->buildAttributeNode(Column::class, $columnOptions, 'ORM');
         } else {
             $comments[] = $this->buildAnnotationLine('@ORM\Column', $columnOptions);
@@ -38,6 +43,17 @@ class EntityManipulator extends ClassManipulator
 
         $this->addClassFieldAsPromotedProperty($propertyName, $typeHintShortName, $nullable, $comments, $attributes);
         $this->addUseStatementIfNecessary($typeHint);
+        if (null !== $columnType) {
+            if (str_starts_with($columnType, 'DecimalType')) {
+                $this->addUseStatementIfNecessary('App\\Shared\\Infrastructure\\Persistence\\Doctrine\\Types\\ArbitraryPrecisionDecimalType');
+            }
+            if (str_starts_with($columnType, 'DateRangeType')) {
+                $this->addUseStatementIfNecessary('App\\Shared\\Infrastructure\\Persistence\\Doctrine\\Types\\DateRangeType');
+            }
+            if (str_starts_with($columnType, 'Doctrine\\DBAL\\Types\\Type')) {
+                $this->addUseStatementIfNecessary('Doctrine\\DBAL\\Types\\Types');
+            }
+        }
         $this->addGetter($propertyName, $typeHintShortName, $nullable);
 
         // don't generate setters for id fields
@@ -75,56 +91,31 @@ class EntityManipulator extends ClassManipulator
 
     protected function getTypeHint(string $doctrineType): ?string
     {
-        switch ($doctrineType) {
-            case 'string':
-            case 'text':
-            case 'guid':
-            case 'bigint':
-                return 'string';
+        return match ($doctrineType) {
+            'string', 'text', 'guid', 'bigint' => 'string',
+            'array', 'simple_array', 'json', 'json_array' => 'array',
+            'boolean' => 'bool',
+            'decimal', 'ap_decimal' => 'Decimal\\Decimal',
+            'integer', 'smallint' => 'int',
+            'float' => 'float',
+            'datetime', 'datetimetz', 'date', 'time' => DateTime::class,
+            'datetime_immutable', 'datetimetz_immutable', 'date_immutable', 'time_immutable' => DateTimeImmutable::class,
+            'dateinterval' => DateInterval::class,
+            'date_range' => 'App\\Shared\\Domain\\ValueObject\\DateTimeRange',
+            default => null,
+        };
+    }
 
-            case 'array':
-            case 'simple_array':
-            case 'json':
-            case 'json_array':
-                return 'array';
-
-            case 'boolean':
-                return 'bool';
-
-            case 'decimal':
-            case 'ap_decimal':
-                return 'Decimal\\Decimal';
-
-            case 'integer':
-            case 'smallint':
-                return 'int';
-
-            case 'float':
-                return 'float';
-
-            case 'datetime':
-            case 'datetimetz':
-            case 'date':
-            case 'time':
-                return DateTime::class;
-
-            case 'datetime_immutable':
-            case 'datetimetz_immutable':
-            case 'date_immutable':
-            case 'time_immutable':
-                return DateTimeImmutable::class;
-
-            case 'dateinterval':
-                return DateInterval::class;
-
-            case 'date_range':
-                return 'App\\Shared\\Domain\\ValueObject\\DateTimeRange';
-
-            case 'object':
-            case 'binary':
-            case 'blob':
-            default:
-                return null;
-        }
+    protected function getColumnType(string $doctrineType): ?string
+    {
+        return match ($doctrineType) {
+            'text' => 'Doctrine\\DBAL\\Types\\Types::TEXT',
+            'decimal', 'ap_decimal' => 'DecimalType::NAME',
+            'datetime', 'datetimetz' => 'Doctrine\\DBAL\\Types\\Types::DATETIME_MUTABLE',
+            'date' => 'Doctrine\\DBAL\\Types\\Types::DATE_MUTABLE',
+            'time' => 'Doctrine\\DBAL\\Types\\Types:TIME_MUTABLE',
+            'date_range' => 'DateRangeType::NAME',
+            default => null,
+        };
     }
 }


### PR DESCRIPTION
Newer PHP syntax introduced.
Entity attributes are left as the only option when declaring entity fields (annotations removed).
Few code-style tweaks